### PR TITLE
Java 11 upgrade to tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jdk.version>1.7</jdk.version>
+		<jdk.version>11</jdk.version>
 		<maven.compiler.source>${jdk.version}</maven.compiler.source>
 		<maven.compiler.target>${jdk.version}</maven.compiler.target>
 	</properties>

--- a/src/test/java/com/github/f4b6a3/uuid/util/TimestampUtilTest.java
+++ b/src/test/java/com/github/f4b6a3/uuid/util/TimestampUtilTest.java
@@ -4,13 +4,16 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 
 public class TimestampUtilTest {
 
 	@Test
 	public void testToInstantFromInstant() {
-		Instant instant1 = Instant.now();
+		Clock test = Clock.tickSeconds(ZoneId.of("UTC"));
+		Instant instant1 = Instant.now(test);
 		long timestamp1 = TimestampUtil.toTimestamp(instant1);
 		Instant instant2 = TimestampUtil.toInstant(timestamp1);
 		assertEquals(instant1, instant2);


### PR DESCRIPTION
Fixed test that relied on Java Instant.now() not supporting nanonseconds see https://bugs.openjdk.java.net/browse/JDK-8068730