### PR TITLE
isParseable should reject chars > 256 instead of throwing ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/com/github/f4b6a3/uuid/util/UuidValidator.java
+++ b/src/main/java/com/github/f4b6a3/uuid/util/UuidValidator.java
@@ -251,7 +251,7 @@ public final class UuidValidator {
 	protected static boolean isParseable(final char[] chars) {
 		int dashCount = 0;
 		for (int i = 0; i < chars.length; i++) {
-			if (MAP.get(chars[i]) == -1) {
+			if (chars[i] > MAP.length() || MAP.get(chars[i]) == -1) {
 				if (chars[i] == '-') {
 					dashCount++;
 					continue;

--- a/src/test/java/com/github/f4b6a3/uuid/util/UuidValidatorTest.java
+++ b/src/test/java/com/github/f4b6a3/uuid/util/UuidValidatorTest.java
@@ -93,6 +93,10 @@ public class UuidValidatorTest {
 		uuid = "01234567-89ab-4def-!@#$-ef0123456789"; // String with non alphanumeric chars
 		assertFalse("UUID string non alphanumeric chars should be invalid.", UuidValidator.isValid(uuid));
 
+
+		uuid = "01234567-89ab-4def-😊🤖-ef0123456789"; // String with UTF8 chars
+		assertFalse("UUID string UTF8 chars should be invalid.", UuidValidator.isValid(uuid));
+
 		try {
 			uuid = null;
 			UuidValidator.validate(uuid);


### PR DESCRIPTION
We're hitting this with human-input values. :)
